### PR TITLE
✨ feat: Add CourseService and CourseRepository implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 	

--- a/src/main/java/com/fatec/horario/repositories/CourseRepository.java
+++ b/src/main/java/com/fatec/horario/repositories/CourseRepository.java
@@ -1,0 +1,5 @@
+package com.fatec.horario.repositories;
+
+public class CourseRepository {
+    
+}

--- a/src/main/java/com/fatec/horario/repositories/CourseRepository.java
+++ b/src/main/java/com/fatec/horario/repositories/CourseRepository.java
@@ -1,5 +1,11 @@
 package com.fatec.horario.repositories;
 
-public class CourseRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.fatec.horario.entities.Course;
+
+@Repository
+public interface CourseRepository extends JpaRepository<Course, Long> {
     
 }

--- a/src/main/java/com/fatec/horario/services/CourseService.java
+++ b/src/main/java/com/fatec/horario/services/CourseService.java
@@ -1,8 +1,6 @@
 package com.fatec.horario.services;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -23,7 +21,7 @@ public class CourseService {
         return repository.findAll()
                 .stream()
                 .map(CourseMapper::toResponse)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public CourseResponse getById(Long id) {
@@ -33,21 +31,19 @@ public class CourseService {
         return CourseMapper.toResponse(course);
     }
 
-    public CourseResponse create(CourseRequest dto) {
-        Course course = CourseMapper.toEntity(dto);
-        Course saved = repository.save(course);
-        return CourseMapper.toResponse(saved);
+    public CourseResponse create(CourseRequest request) {
+        Course course = CourseMapper.toEntity(request);
+        course = repository.save(course);
+        return CourseMapper.toResponse(course);
     }
 
-    public CourseResponse update(Long id, CourseRequest dto) {
+    public CourseResponse update(Long id, CourseRequest request) {
         Course course = repository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Course not found with id: " + id));
-
-        course.setName(dto.name());
-        course.setDescription(dto.description());
-
-        Course updated = repository.save(course);
-        return CourseMapper.toResponse(updated);
+        course.setName(request.name());
+        course.setDescription(request.description());
+        course = repository.save(course);
+        return CourseMapper.toResponse(course);
     }
 
     public void delete(Long id) {

--- a/src/main/java/com/fatec/horario/services/CourseService.java
+++ b/src/main/java/com/fatec/horario/services/CourseService.java
@@ -1,5 +1,59 @@
 package com.fatec.horario.services;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.fatec.horario.dtos.CourseRequest;
+import com.fatec.horario.dtos.CourseResponse;
+import com.fatec.horario.entities.Course;
+import com.fatec.horario.mappers.CourseMapper;
+import com.fatec.horario.repositories.CourseRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@Service
 public class CourseService {
-    
+    @Autowired
+    private CourseRepository repository;
+
+    public List<CourseResponse> getAll() {
+        return repository.findAll()
+                .stream()
+                .map(CourseMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public CourseResponse getById(Long id) {
+        Course course = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Course not found with id: " + id));
+
+        return CourseMapper.toResponse(course);
+    }
+
+    public CourseResponse create(CourseRequest dto) {
+        Course course = CourseMapper.toEntity(dto);
+        Course saved = repository.save(course);
+        return CourseMapper.toResponse(saved);
+    }
+
+    public CourseResponse update(Long id, CourseRequest dto) {
+        Course course = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Course not found with id: " + id));
+
+        course.setName(dto.name());
+        course.setDescription(dto.description());
+
+        Course updated = repository.save(course);
+        return CourseMapper.toResponse(updated);
+    }
+
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new EntityNotFoundException("Course not found with id: " + id);
+        }
+        repository.deleteById(id);
+    }
 }

--- a/src/main/java/com/fatec/horario/services/CourseService.java
+++ b/src/main/java/com/fatec/horario/services/CourseService.java
@@ -1,0 +1,5 @@
+package com.fatec.horario.services;
+
+public class CourseService {
+    
+}


### PR DESCRIPTION
This PR introduces the initial implementation of the CourseService and CourseRepository, enabling full CRUD operations for the Course domain.

### Included
Creation of CourseService.java
- getAll()
- getById(Long id)
- create(CourseRequest dto)
- update(Long id, CourseRequest dto)
- delete(Long id)

Automatic conversion between DTOs and Entity using CourseMapper
Validation and error handling with EntityNotFoundException
Proper use of layered architecture (Service → Repository → Entity)
Creation of CourseRepository.java
Extends JpaRepository
Provides database access for the Course entity